### PR TITLE
Correção da verificação de palavra encontrada.

### DIFF
--- a/Labs/Lab23/Respostas/lab23q5.cpp
+++ b/Labs/Lab23/Respostas/lab23q5.cpp
@@ -25,7 +25,7 @@ int main()
 
 	while (fin >> token && !encontrada)
 	{
-		if (strcmp(token, palavra))
+		if (!strcmp(token, palavra))
 			encontrada = true;
 	}
 	fin.close();


### PR DESCRIPTION
- Adicionada a negação na verificação com o strcmp.

Motivo: Ao realizar a verificação com o strcmp, não foi utilizada a negação, com isso, qualquer palavra não existente no texto seria marcada como encontrada.